### PR TITLE
fix: remove shouldDeflate parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unl-core",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/polyhash/index.js
+++ b/src/polyhash/index.js
@@ -78,20 +78,16 @@ const decode = [
  * Converts an array of points into a polyhash, locationId-polygon
  * 
  * @param {*} points 
- * @param {*} locationIdPrecision 
- * @param {boolean} shouldDeflate - if false, returned polyhash will have full-length, inflated locationIds (default: false)
+ * @param {*} locationIdPrecision
  */
-function toPolyhash(points, locationIdPrecision = 9, shouldDeflate = true) {
+function toPolyhash(points, locationIdPrecision = 9) {
   if (locationIdPrecision > maxLocationIdPrecision) {
     console.error(`Invalid locationId precision ${locationIdPrecision}. Maximum supported is ${maxLocationIdPrecision}`)
     return null
   }
 
   let polyhash = points.map(point => unl.encode(point[0], point[1], locationIdPrecision))
-  if (shouldDeflate)
-    return deflate(polyhash)
-  
-  return polyhash
+  return deflate(polyhash)
 }
 
 /**


### PR DESCRIPTION
Using un-deflated polyhash or clusters currently has unexpected side-effects 

Using (optional) full-length locationIds needs support in all methods, but is not necessary (we have inflate() method)