### PR TITLE
fix: update turf versions to fix patchy cluster bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unl-core",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,73 +25,73 @@
       }
     },
     "@turf/bbox": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
-      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-N1UEnnLGDk+j0a+O2veUhmgo6UNrf9ERtGbbIbTh8D0g5QFpYy3xiNVqUMqyZ/fRP6qR+/VUeSKKri0+UPiDJg==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x"
+        "@turf/helpers": "^6.2.0-alpha.2",
+        "@turf/meta": "^6.2.0-alpha.2"
       }
     },
     "@turf/boolean-contains": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.0.1.tgz",
-      "integrity": "sha512-usAexEdWu7dV43paowGSFEM0PljexnlOuj09HF/VDZwO3FKelwUovF2ymetYatuG7KcIYcexeNEkQ5qQnGExlw==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-vdRspoVsZUt/oJRnSMabmR9xdnqUvTjQfER6lLkiniGigobyeew4Hw3NUtgRXWf72zMG/WjfEf2vuAdBSEYRAQ==",
       "requires": {
-        "@turf/bbox": "6.x",
-        "@turf/boolean-point-in-polygon": "6.x",
-        "@turf/boolean-point-on-line": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/bbox": "^6.2.0-alpha.2",
+        "@turf/boolean-point-in-polygon": "^6.2.0-alpha.2",
+        "@turf/boolean-point-on-line": "^6.2.0-alpha.2",
+        "@turf/helpers": "^6.2.0-alpha.2",
+        "@turf/invariant": "^6.2.0-alpha.2"
       }
     },
     "@turf/boolean-point-in-polygon": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
-      "integrity": "sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-YjqeT68cIynFSaDccZv932qvzWi/YNCNgGRTrrtO6hwkPJFRPLIurCgAsfaqsTmTzdONAeyhMtgCdnRvjMsMSQ==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.2.0-alpha.2",
+        "@turf/invariant": "^6.2.0-alpha.2"
       }
     },
     "@turf/boolean-point-on-line": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.0.1.tgz",
-      "integrity": "sha512-Vl724Tzh4CF/13kgblOAQnMcHagromCP1EfyJ9G/8SxpSoTYeY2G6FmmcpbW51GqKxC7xgM9+Pck50dun7oYkg==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-pThu5mDBojJezRRipHeFhDKe1TUZLkDFTuDN1VI/tw8m2/bOd5thEVODm17cHHaCigIaXsHYlfsMX01SOJah0A==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.2.0-alpha.2",
+        "@turf/invariant": "^6.2.0-alpha.2"
       }
     },
     "@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-YW7Tk75XTbJh3ZBwdo29QE/N4HjxApNV4ZUVJaukBm2Kns/sGMJh9RQPuITOlB5+tW6FUVTMlZYK1PejiVNeAQ=="
     },
     "@turf/intersect": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
-      "integrity": "sha512-SeAJG/zPRRTeyK2OifkPoyLq60q8tv8prpPIH3R8ZhyF4MdLOnMv5MURaQ6kQd+3UTDrL+pYm6rqbPvln1zqIw==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-zynyjFJBRmV4NbiA7if81CpEeA4OIO+Q5OU3kJY2wcgluw6Adm+Yn54FEtMlaTxUgx/xUgazdsmS8Y41SsGvCg==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
+        "@turf/helpers": "^6.2.0-alpha.2",
+        "@turf/invariant": "^6.2.0-alpha.2",
+        "polygon-clipping": "^0.14.3"
       }
     },
     "@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-o4PDDR8LByDFAvLMmra9EkmxaRIbykxrFlRBuWt/uMF2OQ8AMfF3BGbfyCHU9p+0zAskNBhS5SvmLB3e+PcE3A==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.2.0-alpha.2"
       }
     },
     "@turf/meta": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "version": "6.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.2.0-alpha.2.tgz",
+      "integrity": "sha512-Hk2gnRSto/yiT6oO0bHYPiOvWTsgb1dlQm9cTcrrR068Zlfzx/7cJV5Me2Ls085rMBMlT376CgaHySexXVRrIg==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.2.0-alpha.2"
       }
     },
     "acorn": {
@@ -954,15 +954,6 @@
         "chalk": "^2.0.1"
       }
     },
-    "martinez-polygon-clipping": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
-      "integrity": "sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==",
-      "requires": {
-        "splaytree": "^0.1.4",
-        "tinyqueue": "^1.2.0"
-      }
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -1242,6 +1233,14 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "polygon-clipping": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.14.3.tgz",
+      "integrity": "sha512-bIaMFYIsHOShMN0JZsvkfk66S7gKMQMlYUpV7LIx+WOBYvJT09eCgoAv2JCDNj6SofA4+o5tlmV76zzUiG4aBQ==",
+      "requires": {
+        "splaytree": "^3.0.1"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1372,9 +1371,9 @@
       }
     },
     "splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.0.1.tgz",
+      "integrity": "sha512-WvQIHRDXLSVn72xjlIG/WGhv/4QO3m+iY2TpVdFRaXd1+/vkNlpkpw1QaNH5taghF9eWXDHWMWnzXyicR8d6ig=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1487,11 +1486,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The core SDK for UNL Location Services",
   "homepage": "https://unl.global",
   "author": "Emre Turan <emre@unl.global>",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "unl-core.js",
   "repository": {
@@ -119,7 +119,7 @@
     }
   },
   "dependencies": {
-    "@turf/boolean-contains": "^6.0.1",
-    "@turf/intersect": "^6.1.3"
+    "@turf/boolean-contains": "^6.2.0-alpha.2",
+    "@turf/intersect": "^6.2.0-alpha.2"
   }
 }


### PR DESCRIPTION
This updates turf to at least the first version that fixes a bug in the drawing of polygons. See the difference:

<img width="911" alt="Screen Shot 2020-11-04 at 17 16 53" src="https://user-images.githubusercontent.com/19908470/98136816-9e66f100-1ec1-11eb-94c9-e291e7970cd7.png">

<img width="911" alt="Screen Shot 2020-11-04 at 17 16 59" src="https://user-images.githubusercontent.com/19908470/98136834-a3c43b80-1ec1-11eb-9479-377e408c7ada.png">
