### PR TITLE
fix(clustering): fix the order of lat lng when encoding geohashes fro…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,14 @@
         "@turf/meta": "^6.3.0"
       }
     },
+    "@turf/bbox-polygon": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.3.0.tgz",
+      "integrity": "sha512-CCyTBM8LzGRu/lReNlgDyjRO8NojtJ7EPPvSl3bdKQbNFsCm25gwe7Y3xsaCkWLNn5g89lQJI9Izf9xdEsENjQ==",
+      "requires": {
+        "@turf/helpers": "^6.3.0"
+      }
+    },
     "@turf/bearing": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@turf/boolean-overlap": "^6.3.0",
     "@turf/helpers": "^6.3.0",
     "@turf/intersect": "^6.3.0",
-    "@turf/meta": "^6.3.0"
+    "@turf/meta": "^6.3.0",
+    "@turf/bbox-polygon": "^6.3.0"
   }
 }

--- a/src/polyhash/index.js
+++ b/src/polyhash/index.js
@@ -5,6 +5,7 @@ const turfBooleanDisjoint = require("@turf/boolean-disjoint").default;
 const turfIntersect = require("@turf/intersect").default;
 const turfHelpers = require("@turf/helpers");
 const turfMeta = require("@turf/meta");
+const turf = require("@turf/turf");
 
 const maxLocationIdPrecision = 16;
 
@@ -331,15 +332,8 @@ function toCluster(inputPolygon, locationIdPrecision) {
     const _cell = queue[0][0].shift()
     const _testPolygon = queue[0][1]
     // Convert to bounding box polygon
-    const box = unl.bounds(_cell)
-    const bounds = [
-      [box.n, box.e],
-      [box.s, box.e],
-      [box.s, box.w],
-      [box.n, box.w],
-      [box.n, box.e]
-    ];
-    const cellPolygon = turfHelpers.polygon([bounds]);
+    const { n, e, s, w } = unl.bounds(_cell);
+    const cellPolygon = turf.bboxPolygon([w,s,e,n]);
 
     // Check if Cell and polygon are intersecting
     const intersection = _isIntersecting(_testPolygon, cellPolygon);
@@ -360,7 +354,7 @@ function toCluster(inputPolygon, locationIdPrecision) {
         // Then convert intersection polygon points into locationIdes
         intersectionLocationIdsCells = []
         turfMeta.coordEach(_newTestPolygon, function (currentCoord) {
-          const locationId = unl.encode(currentCoord[0], currentCoord[1], locationIdPrecision)
+          const locationId = unl.encode(currentCoord[1], currentCoord[0], locationIdPrecision)
           intersectionLocationIdsCells.push(locationId)
         });
 

--- a/src/polyhash/index.js
+++ b/src/polyhash/index.js
@@ -5,7 +5,7 @@ const turfBooleanDisjoint = require("@turf/boolean-disjoint").default;
 const turfIntersect = require("@turf/intersect").default;
 const turfHelpers = require("@turf/helpers");
 const turfMeta = require("@turf/meta");
-const turf = require("@turf/turf");
+const turfBboxPolygon = require("@turf/bbox-polygon").default;
 
 const maxLocationIdPrecision = 16;
 
@@ -81,8 +81,8 @@ const decode = [
 /**
  * Converts an array of points into a polyhash, locationId-polygon
  *
- * @param {*} points
- * @param {*} locationIdPrecision
+ * @param {point[]} points
+ * @param {int} locationIdPrecision
  */
 function toPolyhash(points, locationIdPrecision = 9) {
   if (locationIdPrecision > maxLocationIdPrecision) {
@@ -333,7 +333,7 @@ function toCluster(inputPolygon, locationIdPrecision) {
     const _testPolygon = queue[0][1]
     // Convert to bounding box polygon
     const { n, e, s, w } = unl.bounds(_cell);
-    const cellPolygon = turf.bboxPolygon([w,s,e,n]);
+    const cellPolygon = turfBboxPolygon([w,s,e,n]);
 
     // Check if Cell and polygon are intersecting
     const intersection = _isIntersecting(_testPolygon, cellPolygon);
@@ -351,12 +351,8 @@ function toCluster(inputPolygon, locationIdPrecision) {
           continue
         }
 
-        // Then convert intersection polygon points into locationIdes
-        intersectionLocationIdsCells = []
-        turfMeta.coordEach(_newTestPolygon, function (currentCoord) {
-          const locationId = unl.encode(currentCoord[1], currentCoord[0], locationIdPrecision)
-          intersectionLocationIdsCells.push(locationId)
-        });
+        // Then convert intersection polygon points into locationIds
+        const intersectionLocationIdsCells = turfMeta.coordAll(_newTestPolygon).map(x => unl.encode(x[1], x[0], locationIdPrecision))
 
         // Then get the locationId that bounds the intersection polygon
         // Done by getting the longest common prefix in all the locationIds

--- a/test/test.polyhash.js
+++ b/test/test.polyhash.js
@@ -63,19 +63,19 @@ describe("Polyhash", function () {
 
   it("toPolyhash: Convert coordinates to a polyhash", function () {
     const coords = [
-      [42.9252986, -72.2794631],
-      [42.9251827, -72.2794363],
-      [42.9252043, -72.2790635],
-      [42.9248076, -72.2789964],
-      [42.9248272, -72.2788462],
-      [42.9251297, -72.2788945],
-      [42.9251572, -72.2784975],
-      [42.9252691, -72.2785324],
-      [42.9252416, -72.2788891],
-      [42.9253595, -72.278924],
-      [42.9253575, -72.2790098],
-      [42.9253261, -72.2790071],
-      [42.9252986, -72.2794631],
+      [42.9252986,-72.2794631],
+      [42.9251827,-72.2794363],
+      [42.9252043,-72.2790635],
+      [42.9248076,-72.2789964],
+      [42.9248272,-72.2788462],
+      [42.9251297,-72.2788945],
+      [42.9251572,-72.2784975],
+      [42.9252691,-72.2785324],
+      [42.9252416,-72.2788891],
+      [42.9253595,-72.278924],
+      [42.9253575,-72.2790098],
+      [42.9253261,-72.2790071],
+      [42.9252986,-72.2794631],
     ];
     const polyHash = libPolyhash.toPolyhash(coords, 9);
 
@@ -117,15 +117,19 @@ describe("Polyhash", function () {
 
     const cluster = libPolyhash.toCluster(coords, 8);
     const expected = [
-      "drss5nr9",
-      "drss5nrc",
-      "drss5nrd",
-      "drss5nrf",
-      "drss5q0p",
-      "drss5q20",
-      "drss5q21",
-      "drss5q23",
-      "drss5q24",
+      "hgnsbccj",
+      "hgnsbccm",
+      "hgnsbccn",
+      "hgnsbccp",
+      "hgnsbccq",
+      "hgnsbccr",
+      "hgnsbf0b",
+      "hgnsbf0c",
+      "hgnsbf10",
+      "hgnsbf11",
+      "hgnsbf12",
+      "hgnsbf14",
+      "hgnsbf15"
     ];
     expect(libPolyhash.inflate(cluster)).to.eql(expected);
   });


### PR DESCRIPTION
We are accepting coordinates in lat/lon format, it is more common to use lon/lat. In fact lon/lat is the offical format for GeoJSON, we should change the apis to match this and avoid mixing up the inputs.

This MR fixes one occurance of this error when getting the geohash for GeoJSON coordinates. 