### PR TITLE
Rewrite Polyhash interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The core SDK for UNL Location Services",
   "homepage": "https://unl.global",
   "author": "Emre Turan <emre@unl.global>",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "license": "MIT",
   "main": "unl-core.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -119,12 +119,13 @@
     }
   },
   "dependencies": {
+    "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-contains": "^6.3.0",
     "@turf/boolean-disjoint": "^6.3.0",
     "@turf/boolean-overlap": "^6.3.0",
     "@turf/helpers": "^6.3.0",
     "@turf/intersect": "^6.3.0",
-    "@turf/meta": "^6.3.0",
-    "@turf/bbox-polygon": "^6.3.0"
+    "@turf/invariant": "^6.3.0",
+    "@turf/meta": "^6.3.0"
   }
 }

--- a/src/polyhash/README.md
+++ b/src/polyhash/README.md
@@ -4,9 +4,24 @@ Encoding geographical areas as locationId based polygons. These polygons are far
 
 ## API
 
-### `toPolyhash`(points, precision)
+### `toCoordinates`(geometry, precision)
 
-Converts an array of LatLng coordinates to a locationId trie.
+Converts coordindates, locationIds, GeoJSON polygon or stringId to a list of coordinates
+The list of coordinates is flattened.
+
+```js
+const locationIds = ["tester", "testsp", "testsj", "testek", "tester"];
+
+const coordinates = tolocationIds(locationIds, 9);
+
+/*
+  coordinates = [[73.976,20.6955],[74.009,20.6955],[74.009,20.6845],[73.976,20.679],[73.976,20.6955]]
+*/
+```
+
+### `toLocationIds`(geometry, precision)
+
+Converts coordindates, locationIds, GeoJSON polygon or stringId to a list of locationIds
 
 ```js
 const coordinates = [
@@ -17,16 +32,36 @@ const coordinates = [
   [ 20.6955, 73.976 ]  // tester
 ];
 
-const polyhash = toPolyhash(coordinates);
+const locationIds = tolocationIds(coordinates, 9);
 
 /*
-  polyhash = [{precision:6, data:['tester','sp','j','ek','er']}]
+  locationIds = ["umnsyfyj2", "umntnbyj8", "umntn8vvx", "umnsydcvr", "umnsyfyj2"]
 */
 ```
 
-### `toCluster`(points, precision)
+### `toPolyhash`(geometry, precision)
 
-Convert a polygon to a cluster of locationIds
+Converts coordindates, locationIds, GeoJSON polygon or stringId to a compressed string
+
+```js
+const coordinates = [
+  [ 20.6955, 73.976 ], // tester
+  [ 20.6955, 74.009 ], // testsp
+  [ 20.6845, 74.009 ], // testsj
+  [ 20.679, 73.976 ],  // testek
+  [ 20.6955, 73.976 ]  // tester
+];
+
+const polyhash = toPolyhash(coordinates, 9);
+
+/*
+  polyhash = "y0mow8c8jEZUKeRoENt+mHjC29xzyMQ="
+*/
+```
+
+### `toCluster`(geometry, precision)
+
+Fill a geometry with a cluster of locationIds. The geometry must be a closed polygon and can be in the form of coordindates, locationIds, GeoJSON polygon or stringId.
 
 ```js
 const coordinates = [
@@ -39,7 +74,7 @@ const coordinates = [
 const cluster = toCluster(coordinates, 6);
 
 /*
-cluster = [{precision:6, data:["testek","m","q","r","s","t","v","w","x","y","z","sj","n","p"]}]
+cluster = ["umnsyd","umnsye","umnsyf","umnsyg","umnsys","umnsyt","umnsyu","umnsyv","umnsyw","umnsyx","umnsyy","umnsyz","umntn8","umntnb"]
 */
 ```
 
@@ -80,33 +115,33 @@ Passing GeoJson polygon
 const cluster = toCluster(polygon, 6);
 
 /*
-cluster = [{precision:6, data:["testek","m","q","r","s","t","v","w","x","y","z","sj","n","p"]}]
+cluster = ["testek","testem","testeq","tester","testes","testet","testev","testew","testex","testey","testez","testesj","testen","testep"]
 */
 ```
 
-### `compressPolyhash`(polyhash)
+### `compress`(locationIds)
 
 Compress a polyhash and return in base64 format.
 
 ```js
-const polyhash = ['tester','sp','j','ek','er'];
-const compressed = compressPolyhash(polyhash);
+const polyhash = ['tester','testsp','testsj','testek','tester'];
+const compressed = compress(locationIds);
 
 /*
   compressed = 'ZNYZN3Y1xNyA'
 */
 ```
 
-### `decompressPolyhash`(compressedPolyhash)
+### `decompress`(stringId)
 
 Decompress a polyhash.
 
 ```js
 const compressedPolyhash = 'ZNYZN3Y1xNyA';
-const polyhash = decompressPolyhash(compressedPolyhash);
+const polyhash = decompress(compressedPolyhash);
 
 /*
-  polyhash = ['tester','sp','j','ek']
+  polyhash = ['tester','testsp','testsj','testek']
 */
 ```
 
@@ -115,7 +150,7 @@ const polyhash = decompressPolyhash(compressedPolyhash);
 Convert a polyhash back into coordinates.
 
 ```js
-const polyhash = ['tester','sp','j','ek','er'];
+const polyhash = ['tester','testsp','testsj','testek','tester'];
 const points = toCoordinates(polyhash);
 
 /*

--- a/src/polyhash/index.js
+++ b/src/polyhash/index.js
@@ -81,7 +81,7 @@ const decode = [
 /**
  * Converts a geometry into a polyhash, locationId-polygon
  *
- * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} input, coordinates, locationIds, polygon or stringId
  * @param {*} locationIdPrecision
  */
 function toPolyhash(input, locationIdPrecision = 9) {
@@ -104,7 +104,7 @@ function toPolyhash(input, locationIdPrecision = 9) {
 /**
  * Convert a geometry into a list of coordinates
  *
- * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} input, coordinates, locationIds, polygon or stringId
  * @param {*} locationIdPrecision
  */
 function toCoordinates(input) {
@@ -162,7 +162,7 @@ function toCoordinates(input) {
 /**
  * Converts a geometry into a list of locationIds
  *
- * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} input, coordinates, locationIds, polygon or stringId
  * @param {*} locationIdPrecision
  */
  function toLocationIds(input, locationIdPrecision = 9) {
@@ -174,7 +174,7 @@ function toCoordinates(input) {
         result = input;
     }
     else {
-      const coords =  toCoordinates(input)
+      const coords = toCoordinates(input)
       result = coords.map(x => unl.encode(x[1], x[0], locationIdPrecision))
     }
     return result;
@@ -370,7 +370,7 @@ function _toTurfPolygon(inputPolygon) {
     else {
       const coords = toCoordinates(inputPolygon)
       // Polygon is an array of points
-        polygons.push(turfHelpers.polygon([coords]));
+      polygons.push(turfHelpers.polygon([coords]));
     }
 
   }
@@ -386,10 +386,10 @@ function _toTurfPolygon(inputPolygon) {
 /**
  * Convert a geometry into a cluster of locationIds
  *
- * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} input, coordinates, locationIds, polygon or stringId
  * @param {*} locationIdPrecision
  */
-function toCluster(input, locationIdPrecision) {
+function toCluster(input, locationIdPrecision = 9) {
 
   if (locationIdPrecision === undefined) {
     console.error("toCluster: locationIdPrecision must be set")
@@ -595,8 +595,8 @@ module.exports = {
   toCoordinates,
   toLocationIds,
   toCluster,
-  compressPolyhash: compress,
-  decompressPolyhash: decompress,
+  compress,
+  decompress,
   inflate,
   deflate,
   groupByPrefix

--- a/src/polyhash/index.js
+++ b/src/polyhash/index.js
@@ -79,31 +79,113 @@ const decode = [
 ];
 
 /**
- * Converts an array of points into a polyhash, locationId-polygon
+ * Converts a geometry into a polyhash, locationId-polygon
  *
- * @param {point[]} points
- * @param {int} locationIdPrecision
+ * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} locationIdPrecision
  */
-function toPolyhash(points, locationIdPrecision = 9) {
+function toPolyhash(input, locationIdPrecision = 9) {
   if (locationIdPrecision > maxLocationIdPrecision) {
     console.error(`Invalid locationId precision ${locationIdPrecision}. Maximum supported is ${maxLocationIdPrecision}`)
     return null
   }
 
-  const polyhash = points.map(point => unl.encode(point[0], point[1], locationIdPrecision))
-  return deflate(polyhash)
+  let result = null;
+  if (typeof input === 'string' || input instanceof String) {
+    result = input;
+  }
+  else {
+    const locationIds = toLocationIds(input)
+    result = compress(locationIds)
+  }
+  return result
 }
 
 /**
- * Returns an array of coordinates, the polygon represented by the given polyhash
+ * Convert a geometry into a list of coordinates
  *
- * @param {*} polyhash
+ * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} locationIdPrecision
  */
-function toCoordinates(polyhash) {
-  return inflate(polyhash).map(locationId => {
-    const point = unl.decode(locationId);
-    return [parseFloat(point.lon.toFixed(6)), parseFloat(point.lat.toFixed(6))]
-  });
+function toCoordinates(input) {
+  try {
+    let result = [];
+    if (input.features) {
+      if (input.features.length) {
+        result.push(...
+          input.features[0].geometry.coordinates.flatMap((arr) =>
+            arr.map((coords) => [coords[0], coords[1]])
+          )
+        );
+      }
+    } else if (input.geometry && input.geometry.type === "MultiPolygon") {
+      const largestPolygon = input.geometry.coordinates.forEach((coords) => {
+        result.push(...coords);
+      });
+    } else if (input.geometry && input.geometry.type === "Polygon") {
+      result.push(...input.geometry.coordinates);
+    }
+    // Array of coords or lists
+    else if (Array.isArray(input) && input.length) {
+      // array of coords
+      if (Array.isArray(input[0])) {
+        result = input;
+      }
+      // Array of locationId
+      else {
+        result = input.map((locationId) => {
+          const point = unl.decode(locationId);
+          return [
+            parseFloat(point.lon.toFixed(6)),
+            parseFloat(point.lat.toFixed(6)),
+          ];
+        });
+      }
+    }
+    else {
+      // compressed string Id
+      const locationIs = decompress(input)
+      result = toCoordinates(locationIs)      
+    }
+    // polyhash
+    return result;
+  } catch (err) {
+    console.error(
+      `Failed to convert ${JSON.stringify(
+        input
+      )} to coordinates, reason: ${err}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Converts a geometry into a list of locationIds
+ *
+ * @param {*} input, coordindates, locationIds, polygon or stringId
+ * @param {*} locationIdPrecision
+ */
+ function toLocationIds(input, locationIdPrecision = 9) {
+  try {
+    let result = [];
+    // If it is a list of location ids
+    if (Array.isArray(input) && input.length &&
+    typeof input[0] === 'string' || input[0] instanceof String) {
+        result = input;
+    }
+    else {
+      const coords =  toCoordinates(input)
+      result = coords.map(x => unl.encode(x[1], x[0], locationIdPrecision))
+    }
+    return result;
+  } catch (err) {
+    console.error(
+      `Failed to convert ${JSON.stringify(
+        input
+      )} to location ids, reason: ${err}`
+    );
+    return null;
+  }
 }
 
 /**
@@ -111,7 +193,8 @@ function toCoordinates(polyhash) {
  *
  * @param {*} polyhash
  */
-function compressPolyhash(polyhash) {
+function compress(locationIds) {
+  let polyhash = deflate(locationIds)
   const blockHeaderBitSize = 1;
   const blockPrecisionHeaderBitSize = 4;
   const charBitSize = 6;
@@ -195,7 +278,7 @@ function compressPolyhash(polyhash) {
  *
  * @param {*} compressedPolyhash
  */
-function decompressPolyhash(compressedPolyhash) {
+function decompress(compressedPolyhash) {
   const buffer = Buffer.from(compressedPolyhash, 'base64');
 
   const result = [];
@@ -285,8 +368,9 @@ function _toTurfPolygon(inputPolygon) {
         polygons.push(turfHelpers.polygon(inputPolygon.geometry.coordinates))
     }
     else {
+      const coords = toCoordinates(inputPolygon)
       // Polygon is an array of points
-        polygons.push(turfHelpers.polygon([inputPolygon]));
+        polygons.push(turfHelpers.polygon([coords]));
     }
 
   }
@@ -300,18 +384,22 @@ function _toTurfPolygon(inputPolygon) {
 
 
 /**
- * Convert the given polygon into a cluster of locationIds
+ * Convert a geometry into a cluster of locationIds
  *
- * @param {*} polygon, Array of coordinates or GeoJSON polygon
+ * @param {*} input, coordindates, locationIds, polygon or stringId
  * @param {*} locationIdPrecision
  */
-function toCluster(inputPolygon, locationIdPrecision) {
+function toCluster(input, locationIdPrecision) {
 
+  if (locationIdPrecision === undefined) {
+    console.error("toCluster: locationIdPrecision must be set")
+    return null
+  }
   const cellAlphabet = "bcdefghjkmnpqrstuvwxyz0123456789";
   const clusterCells = [];
 
   // Convert to turf polygon
-  const polygons = _toTurfPolygon(inputPolygon);
+  const polygons = _toTurfPolygon(input);
 
   if (!polygons) {
     return null
@@ -389,7 +477,7 @@ function toCluster(inputPolygon, locationIdPrecision) {
     // Sort string by length then alphabetically
     return a.length - b.length || a.localeCompare(b)
   })
-  return deflate(sortedClusterCells);
+  return sortedClusterCells;
 }
 
 /**
@@ -505,9 +593,10 @@ function _getIntesection(polygon1, polygon2) {
 module.exports = {
   toPolyhash,
   toCoordinates,
-  compressPolyhash,
-  decompressPolyhash,
+  toLocationIds,
   toCluster,
+  compressPolyhash: compress,
+  decompressPolyhash: decompress,
   inflate,
   deflate,
   groupByPrefix

--- a/test/test.polyhash.js
+++ b/test/test.polyhash.js
@@ -28,10 +28,7 @@ describe("Polyhash", function () {
   });
 
   it("Block header", function () {
-    const polyhash = [
-      { precision: 2, data: ["m9"] },
-      { precision: 1, data: ["m"] },
-    ];
+    const polyhash = ["m9", "mmm"];
     const compressed = libPolyhash.compressPolyhash(polyhash);
     const buffer = Buffer.from(compressed, "base64");
     const binarydata = buffer.readUInt32BE();
@@ -42,7 +39,7 @@ describe("Polyhash", function () {
   });
 
   it("LocationId char terminator", function () {
-    const polyhash = [{ precision: 2, data: ["m9"] }];
+    const polyhash = ["m9"];
     const compressed = libPolyhash.compressPolyhash(polyhash);
     const buffer = Buffer.from(compressed, "base64");
     // First char tarminator for 'm' bit is located after block header [1] and block count [4] at position 5
@@ -56,49 +53,391 @@ describe("Polyhash", function () {
   it("precision Limit: Should return null if precision is bigger than 16", function () {
     const polyHash = libPolyhash.toPolyhash([], 19);
     expect(polyHash).to.eql(null);
-
-    const cluster = libPolyhash.toCluster([], 19);
-    expect(cluster).to.eql(null);
   });
 
-  it("toPolyhash: Convert coordinates to a polyhash", function () {
+  it("toCoordinates(list of coords) should convert list of coordinates to a list of coordinates", function () {
     const coords = [
-      [42.9252986,-72.2794631],
-      [42.9251827,-72.2794363],
-      [42.9252043,-72.2790635],
-      [42.9248076,-72.2789964],
-      [42.9248272,-72.2788462],
-      [42.9251297,-72.2788945],
-      [42.9251572,-72.2784975],
-      [42.9252691,-72.2785324],
-      [42.9252416,-72.2788891],
-      [42.9253595,-72.278924],
-      [42.9253575,-72.2790098],
-      [42.9253261,-72.2790071],
-      [42.9252986,-72.2794631],
+      [42.9252986, -72.2794631],
+      [42.9251827, -72.2794363],
+      [42.9252043, -72.2790635],
+      [42.9248076, -72.2789964],
     ];
-    const polyHash = libPolyhash.toPolyhash(coords, 9);
+    const output = libPolyhash.toCoordinates(coords);
+    expect(coords).to.eql(output);
+  });
+
+  it("toCoordinates(list of locationIds) should convert list of location Ids to a list of coordinates", function () {
+    const locationIdList = ["drsv", "drtjb", "drtj8", "drtj2", "drtj0"];
+    const expected = [
+      [-71.89, 43.15],
+      [-71.697, 43.22],
+      [-71.697, 43.176],
+      [-71.697, 43.132],
+      [-71.697, 43.088],
+    ];
+
+    const coords = libPolyhash.toCoordinates(locationIdList);
+    expect(coords).to.eql(expected);
+  });
+
+  it("toCoordinates(polygon) should convert a polygon to a list of coordinates", function () {
+    const polygon = {
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "46c5c3d3204d8afa8897daeffe91ebc9",
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [24.709158754793236, 46.77376085206123],
+                [24.711213562504298, 46.77260731634826],
+                [24.707912396016837, 46.772722671031545],
+                [24.709158754793236, 46.77376085206123],
+              ],
+              [
+                [24.709158754793236, 46.773414793941726],
+                [24.70865347420778, 46.773091804357335],
+                [24.70952929388872, 46.77302259205115],
+                [24.709158754793236, 46.773414793941726],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
 
     const expected = [
-      "drss5nr9y",
-      "drss5nr9r",
-      "drss5nrcr",
-      "drss5q0p1",
-      "drss5q0ph",
-      "drss5q215",
-      "drss5q23h",
-      "drss5q23u",
-      "drss5q21e",
-      "drss5q246",
-      "drss5q243",
-      "drss5q241",
-      "drss5nr9y",
+      [24.709158754793236, 46.77376085206123],
+      [24.711213562504298, 46.77260731634826],
+      [24.707912396016837, 46.772722671031545],
+      [24.709158754793236, 46.77376085206123],
+      [24.709158754793236, 46.773414793941726],
+      [24.70865347420778, 46.773091804357335],
+      [24.70952929388872, 46.77302259205115],
+      [24.709158754793236, 46.773414793941726],
     ];
 
-    expect(libPolyhash.inflate(polyHash)).to.eql(expected);
+    const coords = libPolyhash.toCoordinates(polygon);
+    expect(coords).to.eql(expected);
   });
 
-  it("toCluster: Convert coordinates to a cluster", function () {
+  it("toCoordinates(stringId) should convert a compressed stringId to a list of coordinates", function () {
+    const stringId = "ygeowUWWj67K9jgCsheAEDoLg1AfAqUaIWWj6A==";
+    const expected = [
+      [42.925279, -72.27946],
+      [42.925193, -72.279418],
+      [42.925193, -72.279074],
+      [42.924807, -72.278988],
+      [42.924807, -72.27886],
+      [42.92515, -72.278903],
+      [42.92515, -72.278516],
+      [42.925279, -72.278516],
+      [42.925236, -72.278903],
+      [42.925365, -72.278945],
+      [42.925365, -72.278988],
+      [42.925322, -72.278988],
+      [42.925279, -72.27946],
+    ];
+
+    const output = libPolyhash.toCoordinates(stringId);
+    expect(output).to.eql(expected);
+  });
+
+  it("toLocationIds(list of locationId) should convert list of locationId to a list of locationId", function () {
+    const locationIds = ["drsv", "drtjb", "drtj8", "drtj2", "drtj0"];
+    const output = libPolyhash.toLocationIds(locationIds);
+    expect(locationIds).to.eql(output);
+  });
+
+  it("toLocationIds(list of coords) should convert list of coords to a list of locationId", function () {
+    const coords = [
+      [42.9252986, -72.2794631],
+      [42.9251827, -72.2794363],
+      [42.9252043, -72.2790635],
+      [42.9248076, -72.2789964],
+    ];
+    const expected = ["hgnsbcc", "hgnsbcc", "hgnsbcc", "hgnsbf0"];
+    const locationIds = libPolyhash.toLocationIds(coords, 7);
+    expect(expected).to.eql(locationIds);
+  });
+
+  it("toLocationIds(polygon) should convert a polygon to a list of locationId", function () {
+    const polygon = {
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "46c5c3d3204d8afa8897daeffe91ebc9",
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [24.709158754793236, 46.77376085206123],
+                [24.711213562504298, 46.77260731634826],
+                [24.707912396016837, 46.772722671031545],
+                [24.709158754793236, 46.77376085206123],
+              ],
+              [
+                [24.709158754793236, 46.773414793941726],
+                [24.70865347420778, 46.773091804357335],
+                [24.70952929388872, 46.77302259205115],
+                [24.709158754793236, 46.773414793941726],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const expected = [
+      "u83d46bsv",
+      "u83d46dnj",
+      "u83d44xyb",
+      "u83d46bsv",
+      "u83d46bdv",
+      "u83d46b31",
+      "u83d46bbt",
+      "u83d46bdv",
+    ];
+
+    const locationIdList = libPolyhash.toLocationIds(polygon);
+    expect(locationIdList).to.eql(expected);
+  });
+
+  it("toLocationIds(stringId) should convert a compressed stringId to a list of coordinates", function () {
+    const stringId = "ygeowUWWj67K9jgCsheAEDoLg1AfAqUaIWWj6A==";
+    const expected = [
+      "hgnsbcc",
+      "hgnsbcc",
+      "hgnsbcc",
+      "hgnsbf0",
+      "hgnsbf0",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbf1",
+      "hgnsbcc",
+    ];
+
+    const locationIdList = libPolyhash.toLocationIds(stringId, 7);
+    expect(locationIdList).to.eql(expected);
+  });
+
+  it("toPolyhash(list of locationId) should convert list of locationId to a polyhash", function () {
+    const locationIds = ["drsv", "drtjb", "drtj8", "drtj2", "drtj0"];
+    const expected = "oYux3VlGpQiQAA==";
+    const polyhash = libPolyhash.toPolyhash(locationIds);
+    expect(expected).to.eql(polyhash);
+  });
+
+  it("toPolyhash(list of coords) should convert list of coords to a polyhash", function () {
+    const coords = [
+      [42.9252986, -72.2794631],
+      [42.9251827, -72.2794363],
+      [42.9252043, -72.2790635],
+      [42.9248076, -72.2789964],
+      [42.9248272, -72.2788462],
+      [42.9251297, -72.2788945],
+      [42.9251572, -72.2784975],
+      [42.9252691, -72.2785324],
+      [42.9252416, -72.2788891],
+      [42.9253595, -72.278924],
+      [42.9253575, -72.2790098],
+      [42.9253261, -72.2790071],
+      [42.9252986, -72.2794631],
+    ];
+    const polyHash = libPolyhash.toPolyhash(coords, 9);
+    const expected = "ygeowUWWj67K9jgCsheAEDoLg1AfAqUaIWWj6A==";
+    expect(polyHash).to.eql(expected);
+  });
+
+  it("toPolyhash(polygon) should convert a polygon to a polyhash", function () {
+    const polygon = {
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "46c5c3d3204d8afa8897daeffe91ebc9",
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [24.709158754793236, 46.77376085206123],
+                [24.711213562504298, 46.77260731634826],
+                [24.707912396016837, 46.772722671031545],
+                [24.709158754793236, 46.77376085206123],
+              ],
+              [
+                [24.709158754793236, 46.773414793941726],
+                [24.70865347420778, 46.773091804357335],
+                [24.70952929388872, 46.77302259205115],
+                [24.709158754793236, 46.773414793941726],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const expected = "y0QGYIMUx2MUxCOvVBimOxnYOEVyM7A=";
+    const polyhash = libPolyhash.toPolyhash(polygon);
+    expect(polyhash).to.eql(expected);
+  });
+
+  it("toCluster(list of locationId) should convert list of locationId to a cluster", function () {
+    const locationIds = [
+      "hgnsbccjx",
+      "hgnsbccjv",
+      "hgnsbccpv",
+      "hgnsbf0bk",
+      "hgnsbf0ch",
+      "hgnsbf10u",
+      "hgnsbf15h",
+      "hgnsbf15p",
+      "hgnsbf10y",
+      "hgnsbf129",
+      "hgnsbf123",
+      "hgnsbf122",
+      "hgnsbccjx",
+    ];
+    const expected = [
+      "hgnsbccjv",
+      "hgnsbccjw",
+      "hgnsbccjx",
+      "hgnsbccjy",
+      "hgnsbccjz",
+      "hgnsbccnj",
+      "hgnsbccnm",
+      "hgnsbccnn",
+      "hgnsbccnp",
+      "hgnsbccnq",
+      "hgnsbccnr",
+      "hgnsbccnt",
+      "hgnsbccnv",
+      "hgnsbccnw",
+      "hgnsbccnx",
+      "hgnsbccny",
+      "hgnsbccnz",
+      "hgnsbccpg",
+      "hgnsbccpj",
+      "hgnsbccpm",
+      "hgnsbccpn",
+      "hgnsbccpp",
+      "hgnsbccpq",
+      "hgnsbccpr",
+      "hgnsbccpt",
+      "hgnsbccpu",
+      "hgnsbccpv",
+      "hgnsbccpw",
+      "hgnsbccpx",
+      "hgnsbccpy",
+      "hgnsbccpz",
+      "hgnsbccr0",
+      "hgnsbccr2",
+      "hgnsbccr8",
+      "hgnsbccrb",
+      "hgnsbf0bk",
+      "hgnsbf0bm",
+      "hgnsbf0bn",
+      "hgnsbf0bp",
+      "hgnsbf0bq",
+      "hgnsbf0br",
+      "hgnsbf0bs",
+      "hgnsbf0bt",
+      "hgnsbf0bu",
+      "hgnsbf0bv",
+      "hgnsbf0bw",
+      "hgnsbf0bx",
+      "hgnsbf0by",
+      "hgnsbf0bz",
+      "hgnsbf0ch",
+      "hgnsbf0cj",
+      "hgnsbf0cn",
+      "hgnsbf0cp",
+      "hgnsbf100",
+      "hgnsbf101",
+      "hgnsbf102",
+      "hgnsbf103",
+      "hgnsbf104",
+      "hgnsbf105",
+      "hgnsbf106",
+      "hgnsbf107",
+      "hgnsbf108",
+      "hgnsbf109",
+      "hgnsbf10b",
+      "hgnsbf10c",
+      "hgnsbf10d",
+      "hgnsbf10e",
+      "hgnsbf10f",
+      "hgnsbf10g",
+      "hgnsbf10h",
+      "hgnsbf10j",
+      "hgnsbf10k",
+      "hgnsbf10m",
+      "hgnsbf10n",
+      "hgnsbf10p",
+      "hgnsbf10q",
+      "hgnsbf10r",
+      "hgnsbf10s",
+      "hgnsbf10t",
+      "hgnsbf10u",
+      "hgnsbf10v",
+      "hgnsbf10w",
+      "hgnsbf10x",
+      "hgnsbf10y",
+      "hgnsbf10z",
+      "hgnsbf110",
+      "hgnsbf11h",
+      "hgnsbf11j",
+      "hgnsbf11k",
+      "hgnsbf11m",
+      "hgnsbf11n",
+      "hgnsbf11q",
+      "hgnsbf11s",
+      "hgnsbf11t",
+      "hgnsbf11u",
+      "hgnsbf11v",
+      "hgnsbf11w",
+      "hgnsbf11y",
+      "hgnsbf120",
+      "hgnsbf122",
+      "hgnsbf123",
+      "hgnsbf128",
+      "hgnsbf129",
+      "hgnsbf14h",
+      "hgnsbf14j",
+      "hgnsbf14k",
+      "hgnsbf14m",
+      "hgnsbf14n",
+      "hgnsbf14p",
+      "hgnsbf14q",
+      "hgnsbf14r",
+      "hgnsbf14s",
+      "hgnsbf14t",
+      "hgnsbf14u",
+      "hgnsbf14v",
+      "hgnsbf14w",
+      "hgnsbf14x",
+      "hgnsbf14y",
+      "hgnsbf14z",
+      "hgnsbf15h",
+      "hgnsbf15j",
+      "hgnsbf15n",
+      "hgnsbf15p",
+    ];
+    const cluster = libPolyhash.toCluster(locationIds, 9);
+    expect(expected).to.eql(cluster);
+  });
+
+  it("toCluster(list of coords) should convert list of coords to a polyhash", function () {
     const coords = [
       [42.9252986, -72.2794631],
       [42.9251827, -72.2794363],
@@ -129,9 +468,93 @@ describe("Polyhash", function () {
       "hgnsbf11",
       "hgnsbf12",
       "hgnsbf14",
-      "hgnsbf15"
+      "hgnsbf15",
     ];
-    expect(libPolyhash.inflate(cluster)).to.eql(expected);
+    expect(cluster).to.eql(expected);
+  });
+
+  it("toCluster(polygon) should convert a polygon to a cluster", function () {
+    const polygon = {
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "46c5c3d3204d8afa8897daeffe91ebc9",
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [24.709158754793236, 46.77376085206123],
+                [24.711213562504298, 46.77260731634826],
+                [24.707912396016837, 46.772722671031545],
+                [24.709158754793236, 46.77376085206123],
+              ],
+              [
+                [24.709158754793236, 46.773414793941726],
+                [24.70865347420778, 46.773091804357335],
+                [24.70952929388872, 46.77302259205115],
+                [24.709158754793236, 46.773414793941726],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const expected = [
+      "th3k83fy",
+      "th3k83fz",
+      "th3k83gp",
+      "th3k864b",
+      "th3k864c",
+      "th3k864f",
+      "th3k864g",
+      "th3k864u",
+      "th3k864v",
+      "th3k864y",
+      "th3k864z",
+      "th3k8650",
+      "th3k8651",
+      "th3k8653",
+      "th3k8654",
+      "th3k8655",
+      "th3k8656",
+      "th3k8657",
+      "th3k865h",
+      "th3k865j",
+      "th3k865k",
+      "th3k865m",
+      "th3k865n",
+      "th3k865p",
+      "th3k865q",
+      "th3k865r",
+      "th3k865s",
+      "th3k865t",
+      "th3k865w",
+      "th3k866b",
+      "th3k866c",
+      "th3k866f",
+      "th3k866g",
+      "th3k866u",
+      "th3k866v",
+      "th3k866y",
+      "th3k866z",
+      "th3k8670",
+      "th3k8671",
+      "th3k8672",
+      "th3k8673",
+      "th3k8674",
+      "th3k8675",
+      "th3k8676",
+      "th3k867h",
+      "th3k867j",
+      "th3k867n",
+      "th3k86db",
+      "th3k86dc",
+    ];
+    const cluster = libPolyhash.toCluster(polygon, 8);
+    expect(cluster).to.eql(expected);
   });
 
   it("toCluster Tiny Area High Precision: Convert coordinates to a cluster", function () {
@@ -143,16 +566,12 @@ describe("Polyhash", function () {
       [4.8983333, 52.3718141],
     ];
 
-    expect(
-      libPolyhash.inflate(libPolyhash.toCluster(coords, 9)).length
-    ).to.be.lessThan(1);
-    expect(
-      libPolyhash.inflate(libPolyhash.toCluster(coords, 13)).length
-    ).to.be.greaterThan(1300);
+    expect(libPolyhash.toCluster(coords, 9)).length.to.be.lessThan(1);
+    expect(libPolyhash.toCluster(coords, 13).length).to.be.greaterThan(1300);
   });
 
   it("compress: Return a compresed polyhash in base64 format", function () {
-    const polyhashList = libPolyhash.deflate(["d", "dr"]);
+    const polyhashList = ["d", "dr"];
     /*
       |--------+--------+----------+------+-------+--------+-----------+------+-------+---------|
       |        | block  |    block | char | char  | block  |     block | char | char  | padding |
@@ -182,10 +601,7 @@ describe("Polyhash", function () {
 
   it("compress and decompress: plain locationIds", function () {
     const locationIdList = ["drsv", "drtjb", "drtj8", "drtj2", "drtj0"];
-
-    const compressed = libPolyhash.compressPolyhash(
-      libPolyhash.deflate(locationIdList)
-    );
+    const compressed = libPolyhash.compressPolyhash(locationIdList);
     const decompressed = libPolyhash.decompressPolyhash(compressed);
     expect(locationIdList).to.eql(decompressed);
   });
@@ -211,7 +627,7 @@ describe("Polyhash", function () {
     const decompressedCluster = libPolyhash.decompressPolyhash(
       compressedCluster
     );
-    expect(libPolyhash.inflate(cluster)).to.eql(decompressedCluster);
+    expect(cluster).to.eql(decompressedCluster);
   });
 
   it("compress and decompress: very large area", function () {
@@ -227,7 +643,7 @@ describe("Polyhash", function () {
     const decompressedCluster = libPolyhash.decompressPolyhash(
       compressedCluster
     );
-    expect(libPolyhash.inflate(cluster)).to.eql(decompressedCluster);
+    expect(cluster).to.eql(decompressedCluster);
   });
 
   it("compress and decompress: GeoJSON featuerCollection object with an empty space in the middle", function () {
@@ -263,7 +679,7 @@ describe("Polyhash", function () {
     const decompressedCluster = libPolyhash.decompressPolyhash(
       compressedCluster
     );
-    expect(libPolyhash.inflate(cluster)).to.eql(decompressedCluster);
+    expect(cluster).to.eql(decompressedCluster);
   });
 
   it("compress and decompress: GeoJSON feature polygon object", function () {
@@ -293,7 +709,7 @@ describe("Polyhash", function () {
     const decompressedCluster = libPolyhash.decompressPolyhash(
       compressedCluster
     );
-    expect(libPolyhash.inflate(cluster)).to.eql(decompressedCluster);
+    expect(cluster).to.eql(decompressedCluster);
   });
 
   it("compress and decompress: GeoJSON feature multi-polygon object", function () {
@@ -372,7 +788,7 @@ describe("Polyhash", function () {
     const decompressedCluster = libPolyhash.decompressPolyhash(
       compressedCluster
     );
-    expect(libPolyhash.inflate(cluster)).to.eql(decompressedCluster);
+    expect(cluster).to.eql(decompressedCluster);
   });
 
   it("compress and decompress: polygon and coords comparision: Clustering a polygon represented as a list coords or a polygon object should return the same cluster", function () {

--- a/test/test.polyhash.js
+++ b/test/test.polyhash.js
@@ -29,7 +29,7 @@ describe("Polyhash", function () {
 
   it("Block header", function () {
     const polyhash = ["m9", "mmm"];
-    const compressed = libPolyhash.compressPolyhash(polyhash);
+    const compressed = libPolyhash.compress(polyhash);
     const buffer = Buffer.from(compressed, "base64");
     const binarydata = buffer.readUInt32BE();
     // First block header is located at bit 0, expected to be set
@@ -40,7 +40,7 @@ describe("Polyhash", function () {
 
   it("LocationId char terminator", function () {
     const polyhash = ["m9"];
-    const compressed = libPolyhash.compressPolyhash(polyhash);
+    const compressed = libPolyhash.compress(polyhash);
     const buffer = Buffer.from(compressed, "base64");
     // First char tarminator for 'm' bit is located after block header [1] and block count [4] at position 5
     // expected to be unset
@@ -590,19 +590,19 @@ describe("Polyhash", function () {
       |--------+--------+--------+--------|
       */
 
-    const base64CompressedPolyhash = libPolyhash.compressPolyhash(polyhashList);
+    const base64CompressedPolyhash = libPolyhash.compress(polyhashList);
     expect(base64CompressedPolyhash).to.eql("jZLc");
   });
 
   it("decompress: Return a compresed polyhash in base64 format", function () {
-    const decompressed = libPolyhash.decompressPolyhash("jZLc");
+    const decompressed = libPolyhash.decompress("jZLc");
     expect(["d", "dr"]).to.eql(decompressed);
   });
 
   it("compress and decompress: plain locationIds", function () {
     const locationIdList = ["drsv", "drtjb", "drtj8", "drtj2", "drtj0"];
-    const compressed = libPolyhash.compressPolyhash(locationIdList);
-    const decompressed = libPolyhash.decompressPolyhash(compressed);
+    const compressed = libPolyhash.compress(locationIdList);
+    const decompressed = libPolyhash.decompress(compressed);
     expect(locationIdList).to.eql(decompressed);
   });
 
@@ -623,8 +623,8 @@ describe("Polyhash", function () {
       [42.9252986, -72.2794631],
     ];
     const cluster = libPolyhash.toCluster(coords, 9);
-    const compressedCluster = libPolyhash.compressPolyhash(cluster);
-    const decompressedCluster = libPolyhash.decompressPolyhash(
+    const compressedCluster = libPolyhash.compress(cluster);
+    const decompressedCluster = libPolyhash.decompress(
       compressedCluster
     );
     expect(cluster).to.eql(decompressedCluster);
@@ -639,8 +639,8 @@ describe("Polyhash", function () {
       [54.140625, 34.3071439],
     ];
     const cluster = libPolyhash.toCluster(coords, 5);
-    const compressedCluster = libPolyhash.compressPolyhash(cluster);
-    const decompressedCluster = libPolyhash.decompressPolyhash(
+    const compressedCluster = libPolyhash.compress(cluster);
+    const decompressedCluster = libPolyhash.decompress(
       compressedCluster
     );
     expect(cluster).to.eql(decompressedCluster);
@@ -675,8 +675,8 @@ describe("Polyhash", function () {
       ],
     };
     const cluster = libPolyhash.toCluster(feature, 10);
-    const compressedCluster = libPolyhash.compressPolyhash(cluster);
-    const decompressedCluster = libPolyhash.decompressPolyhash(
+    const compressedCluster = libPolyhash.compress(cluster);
+    const decompressedCluster = libPolyhash.decompress(
       compressedCluster
     );
     expect(cluster).to.eql(decompressedCluster);
@@ -705,8 +705,8 @@ describe("Polyhash", function () {
       },
     };
     const cluster = libPolyhash.toCluster(feature, 10);
-    const compressedCluster = libPolyhash.compressPolyhash(cluster);
-    const decompressedCluster = libPolyhash.decompressPolyhash(
+    const compressedCluster = libPolyhash.compress(cluster);
+    const decompressedCluster = libPolyhash.decompress(
       compressedCluster
     );
     expect(cluster).to.eql(decompressedCluster);
@@ -784,8 +784,8 @@ describe("Polyhash", function () {
       },
     };
     const cluster = libPolyhash.toCluster(feature, 10);
-    const compressedCluster = libPolyhash.compressPolyhash(cluster);
-    const decompressedCluster = libPolyhash.decompressPolyhash(
+    const compressedCluster = libPolyhash.compress(cluster);
+    const decompressedCluster = libPolyhash.decompress(
       compressedCluster
     );
     expect(cluster).to.eql(decompressedCluster);
@@ -842,10 +842,10 @@ describe("Polyhash", function () {
 
     const clusterFromPoly = libPolyhash.toCluster(polygon, 10);
     const clusterFromCoords = libPolyhash.toCluster(coords, 10);
-    const compressedclusterFromPoly = libPolyhash.compressPolyhash(
+    const compressedclusterFromPoly = libPolyhash.compress(
       clusterFromPoly
     );
-    const compressedclusterFromCoords = libPolyhash.compressPolyhash(
+    const compressedclusterFromCoords = libPolyhash.compress(
       clusterFromCoords
     );
     expect(compressedclusterFromPoly).to.eql(compressedclusterFromCoords);

--- a/test/test.polyhash.js
+++ b/test/test.polyhash.js
@@ -80,50 +80,6 @@ describe("Polyhash", function () {
     expect(coords).to.eql(expected);
   });
 
-  it("toCoordinates(polygon) should convert a polygon to a list of coordinates", function () {
-    const polygon = {
-      type: "FeatureCollection",
-      features: [
-        {
-          id: "46c5c3d3204d8afa8897daeffe91ebc9",
-          type: "Feature",
-          properties: {},
-          geometry: {
-            coordinates: [
-              [
-                [24.709158754793236, 46.77376085206123],
-                [24.711213562504298, 46.77260731634826],
-                [24.707912396016837, 46.772722671031545],
-                [24.709158754793236, 46.77376085206123],
-              ],
-              [
-                [24.709158754793236, 46.773414793941726],
-                [24.70865347420778, 46.773091804357335],
-                [24.70952929388872, 46.77302259205115],
-                [24.709158754793236, 46.773414793941726],
-              ],
-            ],
-            type: "Polygon",
-          },
-        },
-      ],
-    };
-
-    const expected = [
-      [24.709158754793236, 46.77376085206123],
-      [24.711213562504298, 46.77260731634826],
-      [24.707912396016837, 46.772722671031545],
-      [24.709158754793236, 46.77376085206123],
-      [24.709158754793236, 46.773414793941726],
-      [24.70865347420778, 46.773091804357335],
-      [24.70952929388872, 46.77302259205115],
-      [24.709158754793236, 46.773414793941726],
-    ];
-
-    const coords = libPolyhash.toCoordinates(polygon);
-    expect(coords).to.eql(expected);
-  });
-
   it("toCoordinates(stringId) should convert a compressed stringId to a list of coordinates", function () {
     const stringId = "ygeowUWWj67K9jgCsheAEDoLg1AfAqUaIWWj6A==";
     const expected = [
@@ -162,50 +118,6 @@ describe("Polyhash", function () {
     const expected = ["hgnsbcc", "hgnsbcc", "hgnsbcc", "hgnsbf0"];
     const locationIds = libPolyhash.toLocationIds(coords, 7);
     expect(expected).to.eql(locationIds);
-  });
-
-  it("toLocationIds(polygon) should convert a polygon to a list of locationId", function () {
-    const polygon = {
-      type: "FeatureCollection",
-      features: [
-        {
-          id: "46c5c3d3204d8afa8897daeffe91ebc9",
-          type: "Feature",
-          properties: {},
-          geometry: {
-            coordinates: [
-              [
-                [24.709158754793236, 46.77376085206123],
-                [24.711213562504298, 46.77260731634826],
-                [24.707912396016837, 46.772722671031545],
-                [24.709158754793236, 46.77376085206123],
-              ],
-              [
-                [24.709158754793236, 46.773414793941726],
-                [24.70865347420778, 46.773091804357335],
-                [24.70952929388872, 46.77302259205115],
-                [24.709158754793236, 46.773414793941726],
-              ],
-            ],
-            type: "Polygon",
-          },
-        },
-      ],
-    };
-
-    const expected = [
-      "u83d46bsv",
-      "u83d46dnj",
-      "u83d44xyb",
-      "u83d46bsv",
-      "u83d46bdv",
-      "u83d46b31",
-      "u83d46bbt",
-      "u83d46bdv",
-    ];
-
-    const locationIdList = libPolyhash.toLocationIds(polygon);
-    expect(locationIdList).to.eql(expected);
   });
 
   it("toLocationIds(stringId) should convert a compressed stringId to a list of coordinates", function () {


### PR DESCRIPTION
- Add toCoordinates, toLocationIds
- API calls are symmetric.
- It easier to convert from compressed cluster to list of locationIds